### PR TITLE
fix: correct spelling typos in Move source and test files

### DIFF
--- a/move/sources/contra.move
+++ b/move/sources/contra.move
@@ -314,7 +314,7 @@ public fun register<T>(
     key_encryption: Option<KeyEncryption>,
 ) {
     let session_id = account.session_id<T>();
-    let verified_key_encription = ct
+    let verified_key_encryption = ct
         .auditors
         .verify_key_encryption(
             &pk,
@@ -326,7 +326,7 @@ public fun register<T>(
         account,
         auth,
         pk,
-        verified_key_encription,
+        verified_key_encryption,
         session_id,
     );
 }

--- a/move/tests/contra_tests.move
+++ b/move/tests/contra_tests.move
@@ -1817,7 +1817,7 @@ fun verify_well_formed_proof_dst_mismatch_fails() {
     let amount: u16 = 1234;
     let r: u64 = 7777;
     let prover_dst = b"dst-A-prover-21-bytes";
-    let verifier_dst = b"dst-B-verifier-21-byte";
+    let verifier_dst = b"dst-B-verifier-21-bytes";
 
     let ea = encrypted_amount::new_encrypted_amount(
         encrypt_trivial_for_testing(amount as u64, &pk, r),

--- a/move/tests/contra_tests.move
+++ b/move/tests/contra_tests.move
@@ -196,7 +196,7 @@ fun test_simple_flow() {
     let auth = ct.authorize_as_sender(scenario.ctx());
     account_2.merge<TestCurrency>(&auth);
 
-    // Account 2 takes 30 coins from its balance to self. This leaves 20 in the balance since Account 1 transfered 50.
+    // Account 2 takes 30 coins from its balance to self. This leaves 20 in the balance since Account 1 transferred 50.
     let taken_amount = 30;
     let new_balance = encrypted_amount::new_encrypted_amount(
         encrypt_trivial_for_testing(20, &pk_2, 76520),
@@ -1817,7 +1817,7 @@ fun verify_well_formed_proof_dst_mismatch_fails() {
     let amount: u16 = 1234;
     let r: u64 = 7777;
     let prover_dst = b"dst-A-prover-21-bytes";
-    let verifier_dst = b"dst-B-verifier-21-byt";
+    let verifier_dst = b"dst-B-verifier-21-byte";
 
     let ea = encrypted_amount::new_encrypted_amount(
         encrypt_trivial_for_testing(amount as u64, &pk, r),


### PR DESCRIPTION
Closes #6

## Summary
- **contra.move**: Fix variable name typo `verified_key_encription` → `verified_key_encryption`
- **contra_tests.move**: Fix comment typo `transfered` → `transferred` and DST string `byt` → `bytes`