### PR TITLE
[Move] change decoding function to non public entry, fix docs for update_auditors

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The contract implements per-transfer auditing with a single auditor key per toke
 ### Onboarding flow
 
 1. **Generate an auditor keypair off-chain.** The token issuer generates a Twisted ElGamal keypair `(sk, pk)` over Ristretto255.
-2. **Issuer sets the on-chain auditor key.** The issuer calls [`update_auditors`](move/sources/contra.move) with two key vectors, each holding at most one key: `current_pks` (tried first on a transfer; empty disables auditing going forward) and `previous_pks` (also accepted, for a grace window). Grace is caller-driven: rotate with `update_auditors([new], [old])` so in-flight transfers built against the old key still verify, and end the grace with `update_auditors([new], [new])`.
+2. **Issuer sets the on-chain auditor key.** The issuer calls [`update_auditors`](move/sources/contra.move) with two key vectors, each holding at most one key: `current_pks` (tried first on a transfer; empty disables auditing going forward) and `previous_pks` (also accepted, for a grace window). Grace is caller-driven: rotate with `update_auditors([new], [old])` so in-flight transfers built against the old key still verify, and end the grace with `update_auditors([new], [])`.
 3. **Initialize [`ContraAuditor`](ts-sdk/src/auditor.ts).** Construct the SDK with `{ tokenType, privateKeys, table }` — one or more auditor secret keys plus a precomputed discrete-log table (the larger `numBits` is, the faster decryption will be).
 
 ### Reading transfer amounts

--- a/move/sources/contra.move
+++ b/move/sources/contra.move
@@ -20,7 +20,7 @@
 /// 6. Rotate, enable, or disable the auditor keys via `update_auditors` (using the ManagementCap),
 ///    which sets the parallel `current_pks` / `previous_pks` key vectors. A transfer is accepted
 ///    under either set, so pointing `current_pks` at new keys while `previous_pks` still holds the
-///    outgoing keys gives a grace window for in-flight transfers; passing empty vectors disables
+///    outgoing keys gives a grace window for in-flight transfers; passing empty `current_pks` disables
 ///    auditing. Auditing is per-transfer and each transfer carries auditor-readable ciphertexts of
 ///    the amount, one set per auditor key.
 /// 7. [Advanced] Set the policy for the confidential token (using the TreasuryCap). Policies define
@@ -979,8 +979,8 @@ public fun set_policy<T, W>(
 // === Auditor flows ===
 
 /// Replace this confidential token's auditor keys. `current_pks` is tried first when verifying a
-/// transfer, then `previous_pks`. The two does not have to be the same length. The caller can drive a grace
-/// policy: rotate with `update_auditors(new, old_current)` and end the grace with `update_auditors(new, new)`.
+/// transfer, then `previous_pks`. The two do not have to be the same length. The caller can drive a grace
+/// policy: rotate with `update_auditors(new, old_current)` and end the grace with `update_auditors(new, [])`.
 public fun update_auditors<T>(
     ct: &mut ConfidentialToken<T>,
     _cap: &ManagementCap<T>,

--- a/move/sources/decode.move
+++ b/move/sources/decode.move
@@ -12,18 +12,18 @@ use contra::{
 };
 use sui::{group_ops::Element, ristretto255::{G, g_from_bytes, scalar_from_bytes}};
 
-public fun g_vector(parts: vector<vector<u8>>): vector<Element<G>> {
+entry fun g_vector(parts: vector<vector<u8>>): vector<Element<G>> {
     parts.map!(|b| g_from_bytes(&b))
 }
 
 /// Build one `PublicKey` per point-encoded part; each is validated non-identity by `public_key`.
-public fun public_keys(parts: vector<vector<u8>>): vector<PublicKey> {
+entry fun public_keys(parts: vector<vector<u8>>): vector<PublicKey> {
     parts.map!(|b| public_key(g_from_bytes(&b)))
 }
 
 /// Build one `[lo, hi]` handle pair per consecutive pair of point-encoded `parts` (two u32-limb
 /// handles per transferred amount, flattened in amount order). Aborts if `parts` has an odd length.
-public fun auditor_decryption_handles(parts: vector<vector<u8>>): vector<vector<Element<G>>> {
+entry fun auditor_decryption_handles(parts: vector<vector<u8>>): vector<vector<Element<G>>> {
     let elements = g_vector(parts);
     let mut out = vector[];
     let mut i = 0;
@@ -34,11 +34,11 @@ public fun auditor_decryption_handles(parts: vector<vector<u8>>): vector<vector<
     out
 }
 
-public fun encryption(parts: vector<vector<u8>>): Encryption {
+entry fun encryption(parts: vector<vector<u8>>): Encryption {
     encryption_at(&parts, 0)
 }
 
-public fun encrypted_amount(parts: vector<vector<u8>>): EncryptedAmount {
+entry fun encrypted_amount(parts: vector<vector<u8>>): EncryptedAmount {
     new_encrypted_amount(
         encryption_at(&parts, 0),
         encryption_at(&parts, 2),
@@ -47,12 +47,12 @@ public fun encrypted_amount(parts: vector<vector<u8>>): EncryptedAmount {
     )
 }
 
-public fun ddh_proof(parts: vector<vector<u8>>): DdhProof {
+entry fun ddh_proof(parts: vector<vector<u8>>): DdhProof {
     let n = parts.length() - 1;
     nizk::new_ddh_proof(g_range(&parts, 0, n), scalar_from_bytes(parts.borrow(n)))
 }
 
-public fun elgamal_proof(parts: vector<vector<u8>>): ElGamalProof {
+entry fun elgamal_proof(parts: vector<vector<u8>>): ElGamalProof {
     elgamal_proof_at(&parts, 0)
 }
 

--- a/ts-sdk/src/contracts/contra/contra.ts
+++ b/ts-sdk/src/contracts/contra/contra.ts
@@ -27,9 +27,9 @@
  *     ManagementCap), which sets the parallel `current_pks` / `previous_pks` key
  *     vectors. A transfer is accepted under either set, so pointing `current_pks`
  *     at new keys while `previous_pks` still holds the outgoing keys gives a grace
- *     window for in-flight transfers; passing empty vectors disables auditing.
- *     Auditing is per-transfer and each transfer carries auditor-readable
- *     ciphertexts of the amount, one set per auditor key.
+ *     window for in-flight transfers; passing empty `current_pks` disables
+ *     auditing. Auditing is per-transfer and each transfer carries
+ *     auditor-readable ciphertexts of the amount, one set per auditor key.
  * 7.  [Advanced] Set the policy for the confidential token (using the
  *     TreasuryCap). Policies define which operations are permissioned. Currently
  *     supported permissioned operations are:
@@ -1411,10 +1411,10 @@ export interface UpdateAuditorsOptions {
 }
 /**
  * Replace this confidential token's auditor keys. `current_pks` is tried first
- * when verifying a transfer, then `previous_pks`. The two does not have to be the
+ * when verifying a transfer, then `previous_pks`. The two do not have to be the
  * same length. The caller can drive a grace policy: rotate with
  * `update_auditors(new, old_current)` and end the grace with
- * `update_auditors(new, new)`.
+ * `update_auditors(new, [])`.
  */
 export function updateAuditors(options: UpdateAuditorsOptions) {
 	const packageAddress = options.package ?? '@local-pkg/contra';


### PR DESCRIPTION
- non public entry can be modified later
- setting previous_pks to [] results in no op which is cheaper than verification with the same set of keys