### PR TITLE
Fix the e2e call site missed by the `new_balance_pok` rename

### DIFF
--- a/ts-sdk/test/e2e/permissioned.test.ts
+++ b/ts-sdk/test/e2e/permissioned.test.ts
@@ -394,7 +394,7 @@ describe('permissioned & uncovered flows (devnet)', () => {
 						ct: tokenIssuer.confidentialTokenId,
 						pool: poolId,
 						newBalance: newBalanceEa,
-						newBalanceConsistencyProof: newBalancePok,
+						newBalancePok,
 						newBalanceRangeProofs: newBalanceRange,
 						amount: callAmount,
 						balanceProof: buildDdhProof(pid, balanceProof),


### PR DESCRIPTION
E2E is red on `main`: #45 renamed `try_unwrap`'s `new_balance_consistency_proof` to `new_balance_pok` and regenerated the binding, but `permissioned.test.ts` still passed the old argument name, so the call fails at runtime with "Parameter newBalancePok is required".