### PR TITLE
[TS-SDK] Decide merges from pending.terms, not the decrypted amount

### DIFF
--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -35,6 +35,7 @@ import {
 	getAccountId,
 	getConfidentialTokenId,
 	getTokenAccountId,
+	hasPendingDeposits,
 	point,
 	PROTOCOL_AUDITOR_ELGAMAL,
 	PROTOCOL_BATCH_DDH,
@@ -582,10 +583,10 @@ export class ContraClient {
 	}> {
 		// TODO: consider exposing a function that receives the object from the caller,
 		// so that the caller could fetch it differently.
-		const { balance, pending, pendingPublicBalance } = await this.getBalance(tokenAccount);
+		const tokenBalance = await this.getBalance(tokenAccount);
+		const { balance, pending, pendingPublicBalance } = tokenBalance;
 
-		const hasPendingDeposits = pending.amount > 0n || pendingPublicBalance > 0n;
-		const shouldMerge = merge && hasPendingDeposits;
+		const shouldMerge = merge && hasPendingDeposits(tokenBalance);
 
 		const spendable = shouldMerge
 			? balance.amount + pending.amount + pendingPublicBalance
@@ -876,13 +877,13 @@ export class ContraClient {
 	}> {
 		const oldPk = tokenAccount.publicKey;
 		const newPk = newTokenAccount.publicKey;
-		const { balance, pending, pendingPublicBalance } = await this.getBalance(tokenAccount);
+		const tokenBalance = await this.getBalance(tokenAccount);
+		const { balance, pending } = tokenBalance;
 
 		// `rekey_token_account` requires an empty pending balance; merge folds pending (encrypted + public)
 		// into active first. Public deposits contribute a zero handle, so they don't affect the
 		// handle mapping — only the encrypted pending handles do.
-		const shouldMerge =
-			merge && (pending.terms > 0 || pending.amount > 0n || pendingPublicBalance > 0n);
+		const shouldMerge = merge && hasPendingDeposits(tokenBalance);
 
 		const pendingLimbs = pending.ciphertext.limbs;
 		const oldHandles = balance.ciphertext.limbs.map((limb, i) =>

--- a/ts-sdk/src/helpers.ts
+++ b/ts-sdk/src/helpers.ts
@@ -24,7 +24,7 @@ import type { DdhNizk } from './nizk.js';
 import { ElGamalNizk } from './nizk.js';
 import { type RistrettoPoint } from './ristretto255.js';
 import type { Ciphertext } from './twisted_elgamal.js';
-import type { ContraPackageConfig } from './types.js';
+import type { ContraPackageConfig, TokenBalance } from './types.js';
 
 /** BCS layout of the Fiat-Shamir transcript: an ordered list of length-prefixed byte chunks. */
 const FIAT_SHAMIR_TRANSCRIPT = bcs.vector(bcs.vector(bcs.u8()));
@@ -59,6 +59,11 @@ export const PROTOCOL_AUDITOR_ELGAMAL = 0x07;
  * produced by `TokenAccount.decryptWithProof`.
  */
 export const PROTOCOL_VERIFIED_DEC = 100;
+
+/** Whether a `merge` would fold anything in. */
+export function hasPendingDeposits(balance: TokenBalance): boolean {
+	return balance.pending.terms > 0 || balance.pendingPublicBalance > 0n;
+}
 
 /** 20-byte per-account `session_id`: first 20 bytes of {@link getTokenAccountUniqueId}. */
 export function newSessionId(

--- a/ts-sdk/test/e2e/core_flow.test.ts
+++ b/ts-sdk/test/e2e/core_flow.test.ts
@@ -18,6 +18,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 import { ContraAuditor } from '../../src/auditor.js';
 import { TransferEvent as TransferEventBcs } from '../../src/contracts/contra/events.js';
+import { hasPendingDeposits } from '../../src/helpers.js';
 import { G, pointFromBcs, randomScalar } from '../../src/ristretto255.js';
 import { TokenAccount } from '../../src/token_account.js';
 import { EncryptedAmount } from '../../src/twisted_elgamal.js';
@@ -38,6 +39,7 @@ describe('core user flows (devnet)', () => {
 	let expectBalance: Harness['expectBalance'];
 	let expectBalances: Harness['expectBalances'];
 	let setupFreshUsers: Harness['setupFreshUsers'];
+	let setupFreshUsersWithBalance: Harness['setupFreshUsersWithBalance'];
 
 	let user1: Ed25519Keypair;
 	let user1Address: string;
@@ -62,6 +64,7 @@ describe('core user flows (devnet)', () => {
 			expectBalance,
 			expectBalances,
 			setupFreshUsers,
+			setupFreshUsersWithBalance,
 		} = await createHarness());
 
 		// Create user keypairs.
@@ -672,6 +675,59 @@ describe('core user flows (devnet)', () => {
 			await expectBalance(rotated2, {
 				balance: wrapAmount + extra - 1n * ONE,
 				pending: 0n,
+				pendingPublicBalance: 0n,
+				balanceTerms: 1,
+			});
+		},
+	);
+	it(
+		'zero-value deposits occupy terms and merge back out in one call',
+		{ timeout: 300_000 },
+		async () => {
+			// A deposit's term is charged per ciphertext, not per unit of value, so a zero-valued
+			// transfer leg still consumes one of the receiver's bounded deposit slots while
+			// leaving `pending.amount` at zero. `updateBalance` recovers those slots in one PTB:
+			// `merge` clears `pending.terms` and the re-statement resets `active.terms`.
+			const [sender, receiver] = await setupFreshUsersWithBalance([2n * ONE, 0n]);
+
+			const ZERO_LEGS = 3;
+			for (let i = 0; i < ZERO_LEGS; i++) {
+				await transfer(sender.tokenAccount, sender.keypair, receiver.address, 0n);
+			}
+
+			// Every leg is charged a term even though the pending set decrypts to zero.
+			await expectBalance(receiver.tokenAccount, {
+				balance: 0n,
+				pending: 0n,
+				pendingPublicBalance: 0n,
+				balanceTerms: 1,
+			});
+
+			const stuck = await client.contra.getBalance(receiver.tokenAccount);
+			expect(stuck.pending.terms).toBe(ZERO_LEGS);
+			expect(hasPendingDeposits(stuck)).toBe(true);
+
+			// One call, one PTB: merge + re-state.
+			await mergeAndUpdate(receiver.tokenAccount, receiver.keypair);
+
+			await expectBalance(receiver.tokenAccount, {
+				balance: 0n,
+				pending: 0n,
+				pendingPublicBalance: 0n,
+				balanceTerms: 1,
+			});
+
+			// Merging alone would carry the terms into `active`; the re-statement hands the slots back.
+			const after = await client.contra.getBalance(receiver.tokenAccount);
+			expect(after.pending.terms).toBe(0);
+			expect(after.balance.terms).toBe(1);
+			expect(hasPendingDeposits(after)).toBe(false);
+
+			// The account still receives normally afterwards.
+			await transfer(sender.tokenAccount, sender.keypair, receiver.address, ONE);
+			await expectBalance(receiver.tokenAccount, {
+				balance: 0n,
+				pending: ONE,
 				pendingPublicBalance: 0n,
 				balanceTerms: 1,
 			});


### PR DESCRIPTION
If an account's pending deposits are all zero-valued, `#createBalanceUpdate` computed `shouldMerge = false`. `updateBalance` then updated the balance without the preceding `merge`. This resets `active.terms` but leaves `pending.terms` untouched, and since `has_deposit_slot` gates on the sum of the two, the account stays unable to receive.

The user could've instead called `merge` in one transaction followed by `updateBalance` in another, but this is not reachable through the client, is undocumented and is not the intended behaviour. This PR fixes the predicate in `#createBalanceUpdate`.