### PR TITLE
[TS-SDK] Validate recipient amounts in transferBatch

### DIFF
--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -1070,8 +1070,8 @@ export class ContraClient {
 	 * ```
 	 *
 	 * SDK-thrown:
-	 * - `InvalidArgumentError` — `recipients` is empty, has more than 255 entries, or
-	 *   contains the sender's own address.
+	 * - `InvalidArgumentError` — `recipients` is empty, has more than 255 entries,
+	 *   contains the sender's own address, or has an amount outside `[0, 2^64)`.
 	 * - `ReceiverDoesNotAcceptDepositsError` — at least one receiver has paused encrypted
 	 *   deposits or has a per-account freeze active.
 	 * - `InsufficientBalanceError` — total amount exceeds the spendable balance (active,
@@ -1107,6 +1107,15 @@ export class ContraClient {
 		const normalizedSender = normalizeSuiAddress(senderAddress);
 		if (recipients.some((r) => normalizeSuiAddress(r.receiverAddress) === normalizedSender)) {
 			throw new InvalidArgumentError(`Cannot transfer to yourself (${senderAddress}).`);
+		}
+
+		const outOfRange = recipients.flatMap((r, i) =>
+			r.amount < 0n || r.amount >= MAX_AMOUNT_EXCLUSIVE ? [i] : [],
+		);
+		if (outOfRange.length > 0) {
+			throw new InvalidArgumentError(
+				`Transfer amounts must be in [0, 2^64); out of range at index ${outOfRange.join(', ')}.`,
+			);
 		}
 
 		// Fetch every receiver's state in a single multi-get RPC. Surface every
@@ -1396,6 +1405,9 @@ interface AccountState {
 
 /** Max recipients in a single `transferBatch` PTB. Mirrors `MAX_BATCH_RECIPIENTS` in `contra.move`. */
 const MAX_BATCH_RECIPIENTS = 255;
+
+/** Exclusive upper bound on any amount the protocol encodes as four u16 limbs. */
+const MAX_AMOUNT_EXCLUSIVE = 1n << 64n;
 
 /** A prepared receiver amount: its four well-formed limbs (value/blinding/ciphertext) and its pk. */
 type PreparedAmount = { receiverPk: PublicKey; encAmountReceiver: WellFormedLimb[] };

--- a/ts-sdk/test/unit/client_validation.test.ts
+++ b/ts-sdk/test/unit/client_validation.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Client-side input validation that rejects a batch before any network access
+ * or proof construction.
+ */
+
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { describe, expect, it } from 'vitest';
+
+import { contra } from '../../src/client.js';
+import { InvalidArgumentError } from '../../src/error.js';
+import { randomScalar } from '../../src/ristretto255.js';
+import { DiscreteLogTable } from '../../src/twisted_elgamal.js';
+
+const SENDER = `0x${'11'.repeat(32)}`;
+const RECEIVER = `0x${'22'.repeat(32)}`;
+const TOKEN_TYPE = `0x${'33'.repeat(32)}::test_token::TEST_TOKEN`;
+
+const client = new SuiGrpcClient({ network: 'devnet', baseUrl: 'http://127.0.0.1:1' }).$extend(
+	contra({
+		packageConfig: {
+			packageId: `0x${'44'.repeat(32)}`,
+			accountRegistryId: `0x${'55'.repeat(32)}`,
+			tokenRegistryId: `0x${'66'.repeat(32)}`,
+		},
+		table: DiscreteLogTable.create(1),
+	}),
+);
+
+const tokenAccount = client.contra.tokenAccount({
+	address: SENDER,
+	tokenType: TOKEN_TYPE,
+	privateKey: randomScalar(),
+});
+
+describe('transferBatch amount validation', () => {
+	// `intoLimbs` reduces mod 2^64, so an unvalidated out-of-range amount would encrypt a
+	// different value than the one checked against the spendable balance.
+	it.each([
+		['negative', -100n],
+		['2^64', 1n << 64n],
+		['above 2^64', (1n << 64n) + 7n],
+	])('rejects a %s amount', async (_label, amount) => {
+		await expect(
+			client.contra.transferBatch({
+				tokenAccount,
+				recipients: [{ receiverAddress: RECEIVER, amount }],
+			}),
+		).rejects.toThrow(InvalidArgumentError);
+	});
+
+	it('rejects a batch whose out-of-range amounts cancel in the total', async () => {
+		await expect(
+			client.contra.transferBatch({
+				tokenAccount,
+				recipients: [
+					{ receiverAddress: RECEIVER, amount: (1n << 64n) + 7n },
+					{ receiverAddress: `0x${'77'.repeat(32)}`, amount: -(1n << 64n) + 50n },
+				],
+			}),
+		).rejects.toThrow(InvalidArgumentError);
+	});
+
+	// A zero-value leg is legitimate: the chain charges a deposit term per ciphertext, not per
+	// unit of value, so it is only rejected for `wrap` and `unwrap`.
+	it.each([
+		['zero', 0n],
+		['positive', 100n],
+	])('accepts a %s amount (failing later, on network access)', async (_label, amount) => {
+		await expect(
+			client.contra.transferBatch({
+				tokenAccount,
+				recipients: [{ receiverAddress: RECEIVER, amount }],
+			}),
+		).rejects.not.toThrow(InvalidArgumentError);
+	});
+});


### PR DESCRIPTION
`transferBatch` accepted any bigint amount. `intoLimbs` reduces mod 2^64, while the balance-sufficiency check sums the raw amounts, so an out-of-range amount encrypted a different value than the one checked against the spendable balance.

Reject amounts outside `[1, 2^64)` up front, mirroring `unwrap`.