### PR TITLE
[TS-SDK] Keep balance amounts out of error messages

### DIFF
--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -1315,7 +1315,7 @@ export class ContraClient {
 		auth,
 	}: UnwrapOptions): Promise<(tx: Transaction) => TransactionResult> {
 		if (amount <= 0n) {
-			throw new InvalidArgumentError(`Unwrap amount must be positive, got ${amount}.`);
+			throw new InvalidArgumentError('Unwrap amount must be positive.');
 		}
 		const { address, tokenType } = tokenAccount;
 

--- a/ts-sdk/src/error.ts
+++ b/ts-sdk/src/error.ts
@@ -32,7 +32,7 @@ export class InsufficientBalanceError extends ContraError {
 	readonly spendable: bigint;
 	readonly scope: 'active' | 'total';
 	constructor(amount: bigint, spendable: bigint, scope: 'active' | 'total') {
-		super(`Insufficient balance: trying to spend ${amount} but ${scope} balance is ${spendable}.`);
+		super(`Insufficient ${scope} balance for the requested amount.`);
 		this.amount = amount;
 		this.spendable = spendable;
 		this.scope = scope;


### PR DESCRIPTION
`InsufficientBalanceError`'s message embedded the requested amount and the spendable balance, both confidential, where they can reach logs and error reports. They remain available as fields on the error. `unwrap`'s rejection message no longer interpolates its amount either, so no SDK error message carries an amount.