### PR TITLE
[TS-SDK] Document the provenance contract for verified decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Alongside the controls above, the issuer can register an auditor public key so a
 
 Independently of the auditor flow, a user may voluntarily reveal a decrypted value — a balance or the amount on a specific `TransferEvent` — alongside a zero-knowledge proof that the cleartext matches the on-chain ciphertext under their public key. The verifier checks the proof against the public key without learning the user's secret key.
 
+A wallet should only open ciphertexts it fetched from chain itself — a supplied one carries no evidence of its origin and may be a disguised copy of the user's own balance. The proof is bound to the account, not to a verifier, so its recipient can show it to anyone.
+
 ### Permissioned user flows [advanced]
 
 By default `register`, `wrap`, and `unwrap` are open to any holder of `T`. The issuer can install a policy that gates any subset of those operations behind their own contract via a witness type. The wrapper functions are then free to enforce arbitrary checks — KYC, sanctions/screening lists, allowlists, rate limits, per-user caps — before authorizing the underlying flow. Confidential transfers between already-registered accounts remain permissionless even under the strictest policy, so user-to-user privacy is unaffected. The [closed-loop app](apps/closed-loop/) is an example that gates `register` behind a whitelist.

--- a/ts-sdk/src/token_account.ts
+++ b/ts-sdk/src/token_account.ts
@@ -75,6 +75,11 @@ export class TokenAccount {
 	 * `verifiedDecDst = dst(newSessionId(packageConfig, address, tokenType), PROTOCOL_VERIFIED_DEC)`
 	 * and checks the proof with
 	 * `ciphertext.verifyDecryption(verifiedDecDst, publicKey, value, proof)`.
+	 *
+	 * Only open a ciphertext the wallet fetched from chain itself: this decrypts whatever it is
+	 * given under the account's long-term key, and a supplied ciphertext may be a re-randomized —
+	 * hence unrecognizable — copy of the owner's own balance. The proof is bound to the account,
+	 * not to a verifier, so its recipient can replay it to anyone.
 	 */
 	decryptWithProof(
 		ciphertext: Ciphertext,


### PR DESCRIPTION
Document that `decryptWithProof` opens any ciphertext it is given under the account's long-term key, so a wallet should only open ciphertexts it fetched from chain itself.