### PR TITLE
[Docs] State that RPC-fetched encryption keys are unauthenticated

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ A confidential balance is therefore four Twisted ElGamal ciphertexts. Decryption
 
 The homomorphism lets the contract fold incoming encrypted deposits into the running encrypted balance without decrypting, but each addition can grow a limb beyond its original `u16` range. Starting from limbs of at most `2^16`, summing `k` such ciphertexts produces limbs of at most `k * 2^16`. The contract caps `k` at `2^16`, so each limb stays below `2^32` and remains decryptable from the precomputed table. This bound is tracked on-chain: after roughly `2^16` deposits without a merge, further deposits are rejected until the recipient merges the pending balance into the active one (which resets the bound).
 
+### Trust in the RPC endpoint
+
+The SDK encrypts transfer amounts under receiver and auditor keys read from the configured RPC, and those reads are unauthenticated. A hostile endpoint can substitute its own key and read the amounts off the transaction the client builds — the chain's receiver-key check keeps funds safe, but not confidentiality.
+
 ## Balance Model
 
 A confidential token account holds three separate balances:

--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -151,6 +151,9 @@ export class ContraClient {
 	 * Multi-get version of `#getAccountState`. Issues a single
 	 * `core.getObjects` RPC for all addresses, preserving order. Throws
 	 * `TokenAccountDoesNotExistError` if any address has no `TokenAccount<T>` for the token.
+	 *
+	 * The returned keys are unauthenticated RPC data: a hostile endpoint can substitute its own,
+	 * and transfer amounts are encrypted under whatever it returns.
 	 */
 	async #getAccountStates(
 		addresses: readonly string[],
@@ -357,7 +360,8 @@ export class ContraClient {
 	 * Fetch the current per-transfer auditor configuration for the given token type: the current
 	 * auditor public keys (one per auditor; empty when auditing is disabled). Every transfer must carry
 	 * one auditor-readable ciphertext set per key. (The rotation grace window — the `previous_pks` set —
-	 * is enforced entirely on chain, so senders only need the current keys.)
+	 * is enforced entirely on chain, so senders only need the current keys.) Like the receiver keys,
+	 * these are unauthenticated RPC data.
 	 *
 	 * @example
 	 * ```ts


### PR DESCRIPTION
Document that the receiver and auditor keys the SDK encrypts transfer amounts under come from unauthenticated RPC reads, so the endpoint is part of the user's trust base.