### PR TITLE
[Docs] Say that a token has at most one auditor key

### DIFF
--- a/move/sources/contra.move
+++ b/move/sources/contra.move
@@ -18,10 +18,10 @@
 ///    both the public and the private coin; to freeze only the private coin, see items 2 and 3.
 /// 6. Rotate, enable, or disable the auditor keys via `update_auditors` (using the ManagementCap),
 ///    which sets the parallel `current_pks` / `previous_pks` key vectors. A transfer is accepted
-///    under either set, so pointing `current_pks` at new keys while `previous_pks` still holds the
-///    outgoing keys gives a grace window for in-flight transfers; passing empty `current_pks` disables
-///    auditing. Auditing is per-transfer and each transfer carries auditor-readable ciphertexts of
-///    the amount, one set per auditor key.
+///    under either set, so pointing `current_pks` at the new key while `previous_pks` still holds the
+///    outgoing one gives a grace window for in-flight transfers; passing empty `current_pks` disables
+///    auditing. Each vector holds at most one key. Auditing is per-transfer: a transfer carries
+///    auditor-readable ciphertexts of the amount under the single key its package verifies against.
 /// 7. [Advanced] Set the policy for the confidential token (using the TreasuryCap). Policies define
 ///    which operations are permissioned. Currently supported permissioned operations are:
 ///    - `register`: Register a token account for a token type `T`. E.g., caller ensures the user is
@@ -287,9 +287,10 @@ public use fun share_confidential_token as ConfidentialToken.share;
 /// Requires a `&mut TreasuryCap` for authorization, this is to prevent frozen
 /// TreasuryCaps from being used.
 ///
-/// Sets the token's auditor keys to `auditor_public_keys` (per-transfer auditing); every transfer will
-/// carry one auditor-readable ciphertext set per key. Pass an empty vector to start with auditing
-/// disabled. The issuer can enable, rotate, or disable the keys later via `update_auditors`.
+/// Sets the token's auditor key to `auditor_public_keys`, which holds at most one key (per-transfer
+/// auditing); every transfer will carry an auditor-readable ciphertext set under it. Pass an empty
+/// vector to start with auditing disabled. The issuer can enable, rotate, or disable the key later
+/// via `update_auditors`.
 ///
 /// Returns the created `ConfidentialToken` and a `ManagementCap` that can be used to perform
 /// administrative operations for this token.
@@ -928,9 +929,9 @@ public fun set_policy<T, W>(
 
 // === Auditor flows ===
 
-/// Replace this confidential token's auditor keys. `current_pks` is tried first when verifying a
-/// transfer, then `previous_pks`. The two do not have to be the same length. The caller can drive a grace
-/// policy: rotate with `update_auditors(new, old_current)` and end the grace with `update_auditors(new, [])`.
+/// Replace this confidential token's auditor keys, each vector holding at most one key. `current_pks`
+/// is tried first when verifying a transfer, then `previous_pks`. The caller can drive a grace policy:
+/// rotate with `update_auditors(new, old_current)` and end the grace with `update_auditors(new, [])`.
 public fun update_auditors<T>(
     ct: &mut ConfidentialToken<T>,
     _cap: &ManagementCap<T>,

--- a/ts-sdk/src/contracts/contra/contra.ts
+++ b/ts-sdk/src/contracts/contra/contra.ts
@@ -25,10 +25,11 @@
  * 6.  Rotate, enable, or disable the auditor keys via `update_auditors` (using the
  *     ManagementCap), which sets the parallel `current_pks` / `previous_pks` key
  *     vectors. A transfer is accepted under either set, so pointing `current_pks`
- *     at new keys while `previous_pks` still holds the outgoing keys gives a grace
- *     window for in-flight transfers; passing empty `current_pks` disables
- *     auditing. Auditing is per-transfer and each transfer carries
- *     auditor-readable ciphertexts of the amount, one set per auditor key.
+ *     at the new key while `previous_pks` still holds the outgoing one gives a
+ *     grace window for in-flight transfers; passing empty `current_pks` disables
+ *     auditing. Each vector holds at most one key. Auditing is per-transfer: a
+ *     transfer carries auditor-readable ciphertexts of the amount under the single
+ *     key its package verifies against.
  * 7.  [Advanced] Set the policy for the confidential token (using the
  *     TreasuryCap). Policies define which operations are permissioned. Currently
  *     supported permissioned operations are:
@@ -357,10 +358,10 @@ export interface NewConfidentialTokenOptions {
  * Requires a `&mut TreasuryCap` for authorization, this is to prevent frozen
  * TreasuryCaps from being used.
  *
- * Sets the token's auditor keys to `auditor_public_keys` (per-transfer auditing);
- * every transfer will carry one auditor-readable ciphertext set per key. Pass an
- * empty vector to start with auditing disabled. The issuer can enable, rotate, or
- * disable the keys later via `update_auditors`.
+ * Sets the token's auditor key to `auditor_public_keys`, which holds at most one
+ * key (per-transfer auditing); every transfer will carry an auditor-readable
+ * ciphertext set under it. Pass an empty vector to start with auditing disabled.
+ * The issuer can enable, rotate, or disable the key later via `update_auditors`.
  *
  * Returns the created `ConfidentialToken` and a `ManagementCap` that can be used
  * to perform administrative operations for this token.
@@ -1461,9 +1462,9 @@ export interface UpdateAuditorsOptions {
 	typeArguments: [string];
 }
 /**
- * Replace this confidential token's auditor keys. `current_pks` is tried first
- * when verifying a transfer, then `previous_pks`. The two do not have to be the
- * same length. The caller can drive a grace policy: rotate with
+ * Replace this confidential token's auditor keys, each vector holding at most one
+ * key. `current_pks` is tried first when verifying a transfer, then
+ * `previous_pks`. The caller can drive a grace policy: rotate with
  * `update_auditors(new, old_current)` and end the grace with
  * `update_auditors(new, [])`.
  */

--- a/ts-sdk/src/types.ts
+++ b/ts-sdk/src/types.ts
@@ -313,9 +313,10 @@ export interface AccountStatus {
 /** Return value of `ContraClient.getAuditor`: the token's per-transfer auditor configuration. */
 export interface TokenAuditor {
 	/**
-	 * The current auditor public keys (one per auditor); empty when auditing is disabled. When
-	 * non-empty, transfers must attach one per-transfer auditor-readable ciphertext set per key. (The
-	 * rotation grace window — the `previous_pks` set — is enforced on chain, so it is not surfaced here.)
+	 * The current auditor public key, as a vector holding at most one key; empty when auditing is
+	 * disabled. When non-empty, transfers must attach a per-transfer auditor-readable ciphertext set
+	 * under it. (The rotation grace window — the `previous_pks` set — is enforced on chain, so it is
+	 * not surfaced here.)
 	 */
 	currentPks: RistrettoPoint[];
 }


### PR DESCRIPTION
The doc comments described a set of auditor keys with one ciphertext set per key, while `auditors::new`/`update` assert each vector holds at most one.